### PR TITLE
Mirror pages to github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ gem "pry"
 gem "colorize"
 gem "capybara"
 gem "poltergeist"
+gem "everypoliticianbot", github: 'everypolitician/everypoliticianbot'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: git://github.com/everypolitician/everypoliticianbot.git
+  revision: 736835a753e2f0b88fe51ff186d4831ee5b56797
+  specs:
+    everypoliticianbot (0.1.0)
+      git (~> 1.2)
+      octokit (~> 4.1)
+
+GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
@@ -21,6 +29,9 @@ GEM
     cliver (0.3.2)
     coderay (1.1.1)
     colorize (0.7.7)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    git (1.3.0)
     httpclient (2.7.1)
     method_source (0.8.2)
     mime-types (3.0)
@@ -28,8 +39,11 @@ GEM
     mime-types-data (3.2016.0221)
     mini_portile2 (2.0.0)
     multi_json (1.11.2)
+    multipart-post (2.0.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
+    octokit (4.3.0)
+      sawyer (~> 0.7.0, >= 0.5.3)
     open-uri-cached (0.0.5)
     poltergeist (1.9.0)
       capybara (~> 2.1)
@@ -43,6 +57,9 @@ GEM
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
+    sawyer (0.7.0)
+      addressable (>= 2.3.5, < 2.5)
+      faraday (~> 0.8, < 0.10)
     slop (3.6.0)
     sqlite3 (1.3.11)
     sqlite_magic (0.0.6)
@@ -59,6 +76,7 @@ PLATFORMS
 DEPENDENCIES
   capybara
   colorize
+  everypoliticianbot!
   nokogiri
   open-uri-cached
   poltergeist

--- a/scraper.rb
+++ b/scraper.rb
@@ -360,7 +360,11 @@ end
 
 include Everypoliticianbot::Github
 with_git_repo('struan/spain_congreso_es', branch: 'mirror-data', message: 'updating mirrored pages') do
-  Mirror.new.mirror_pages('http://www.congreso.es/portal/page/portal/Congreso/Congreso/Diputados/DiputadosTodasLegislaturas')
+  begin
+    Mirror.new.mirror_pages('http://www.congreso.es/portal/page/portal/Congreso/Congreso/Diputados/DiputadosTodasLegislaturas')
+  rescue
+    puts "failed to mirror all pages"
+  end
 end
 
 #scrape_people('http://www.congreso.es/portal/page/portal/Congreso/Congreso/Diputados/DiputadosTodasLegislaturas')

--- a/scraper.rb
+++ b/scraper.rb
@@ -49,6 +49,8 @@ class Mirror
   # this visits and saves the page 
   def visit_and_save_page(url)
     visit url
+    return if page.status_code != 200
+
     path = File.join('.', CACHE_DIR, sha_url(url))
 
     return if File.exist?(path)

--- a/scraper.rb
+++ b/scraper.rb
@@ -62,6 +62,7 @@ class Mirror
 
   def save_pages_for_person(url)
     visit_and_save_page(url)
+    return if not page.has_css?('div.soporte_year li a')
     all_terms_url = find('div.soporte_year li a')['href'].match('.*listadoFichas.*').to_a.first.to_s
     visit_and_save_page(all_terms_url)
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -7,6 +7,7 @@ require 'capybara'
 require 'capybara/dsl'
 require 'capybara/poltergeist'
 require 'pry'
+require 'everypoliticianbot'
 
 CACHE_DIR = 'cache'
 
@@ -26,7 +27,6 @@ Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, options)
 end
 
-include Capybara::DSL
 Capybara.default_driver = :poltergeist
 
 
@@ -37,6 +37,8 @@ class String
 end
 
 class Mirror
+  include Capybara::DSL
+
   attr_accessor :url
 
   def save_page(url)
@@ -347,7 +349,10 @@ def scrape_person(term, url)
   ScraperWiki.save_sqlite([:id, :term], data)
 end
 
-Mirror.new.mirror_pages('http://www.congreso.es/portal/page/portal/Congreso/Congreso/Diputados/DiputadosTodasLegislaturas')
+include Everypoliticianbot::Github
+with_git_repo('struan/spain_congreso_es', branch: 'mirror-data', message: 'updating mirrored pages') do
+  Mirror.new.mirror_pages('http://www.congreso.es/portal/page/portal/Congreso/Congreso/Diputados/DiputadosTodasLegislaturas')
+end
 
 #scrape_people('http://www.congreso.es/portal/page/portal/Congreso/Congreso/Diputados/DiputadosTodasLegislaturas')
 #scrape_memberships()


### PR DESCRIPTION
This runs over all the pages on the site, saving them to a local cache directory and then using everypoliticianbot's `with_git_repo` magic commits them to the mirror-data branch of this repository.

Files are saved as a SHA of the absolute URL with the session data stripped out - see `Mirror.sha_url` for details of this. If a file with the same SHA as the URL exists it will not save the page. It will still visit the page though.

The actual scraping works by visiting every person page listed on the all people page of the site (http://www.congreso.es/portal/page/portal/Congreso/Congreso/Diputados/DiputadosTodasLegislaturas) and from there visiting the page that lists all the terms that person was elected to and visiting all the person pages linked from there.

Once it has done a complete sweep of all the pages it commits them, or if there is an exception then it commits what it has.

I've left in all the old code that scraped and parsed the existing site, although it might be easier to delete most of it, but at least the CSS/XPath bits might be useful.

Improvements that could be made:
- [ ] Commit as we go so that each file is commited once it's been saved. I've not done this as the current way `everypoliticianbot` works doesn't allow this - if you move the `with_git_repo` wrapper round the file writing then it falls over
- [ ] Better checks that the pages it's getting are the pages we expect. Sometime the site responds with error pages but they still have a 200 status code.
- [ ] Rescraping existing files. If a file with the same SHA as the URL exists it currently moves on to the next page. This means we won't pick up changes at the moment
- [ ] Maybe a mode where it only visits a page if it doesn't exist in the cache. I'm not sure how well this would work with Capybara.
