### PR TITLE
Use :github shortcut in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,15 @@
 # Find out more: https://morph.io/documentation/ruby
 
 source "https://rubygems.org"
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby "2.0.0"
 
-gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
+gem "scraperwiki", github: "openaustralia/scraperwiki-ruby", branch: "morph_defaults"
 gem "nokogiri"
 gem "open-uri-cached"
 gem "pry"
 gem "colorize"
 gem "capybara"
 gem "poltergeist"
-gem 'scraped_page_archive', git: "https://github.com/everypolitician/scraped_page_archive", branch: "master"
+gem 'scraped_page_archive', github: "everypolitician/scraped_page_archive", branch: "master"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/everypolitician/scraped_page_archive
+  remote: https://github.com/everypolitician/scraped_page_archive.git
   revision: 9d8a6347d122d42a983ba28ff84d24de6bdca8a0
   branch: master
   specs:
@@ -88,5 +88,8 @@ DEPENDENCIES
   scraped_page_archive!
   scraperwiki!
 
+RUBY VERSION
+   ruby 2.0.0p648
+
 BUNDLED WITH
-   1.13.2
+   1.13.5


### PR DESCRIPTION
This redefines the :github git source in the `Gemfile` so that it
fetches from an https:// url and updates the entries in the Gemfile to
use that shortcut.
